### PR TITLE
Fix fuzzy date trigger bug #32

### DIFF
--- a/src/ts/contentScripts/dispatcher/index.ts
+++ b/src/ts/contentScripts/dispatcher/index.ts
@@ -20,6 +20,6 @@ const dispatchMap = new Map([
 
 browser.runtime.onMessage.addListener(command => dispatchMap.get(command)?.())
 
-document.addEventListener('keyup', ev => {
+document.addEventListener('keypress', ev => {
     if (ev.key === guard) replaceFuzzyDate()
 })

--- a/src/ts/contentScripts/dispatcher/index.ts
+++ b/src/ts/contentScripts/dispatcher/index.ts
@@ -21,5 +21,5 @@ const dispatchMap = new Map([
 browser.runtime.onMessage.addListener(command => dispatchMap.get(command)?.())
 
 document.addEventListener('keypress', ev => {
-    if (ev.key === guard) replaceFuzzyDate()
+    if (ev.key === guard) setTimeout(function(){ replaceFuzzyDate() },0)
 })


### PR DESCRIPTION
Fix for keyboard layouts where the guard character takes multiple keystrokes, eg. "alt + ,"

See: https://github.com/roam-unofficial/roam-toolkit/issues/32