### PR TITLE
Fix contentScripts getting loaded multiple times

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,17 +34,7 @@
     },
     "content_scripts": [
         {
-            "js": [
-                "shortcuts.js",
-                "navigation.js",
-                "srs.js",
-                "inc-dec-value.js",
-                "dispatcher.js",
-                "block-manipulation.js",
-                "custom-css.js",
-                "fuzzy_date.js",
-                "create-block-demo.js"
-            ],
+            "js": ["entry.js"],
             "matches": ["*://roamresearch.com/*"]
         }
     ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
     "icons": {
         "128": "assets/icon-128.png"
     },
-    "content_security_policy": "script-src 'self'; object-src 'self'",
+    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
     "permissions": [
         "activeTab",
         "alarms",

--- a/src/ts/contentScripts/block-manipulation/index.tsx
+++ b/src/ts/contentScripts/block-manipulation/index.tsx
@@ -1,6 +1,7 @@
 import {Feature, Shortcut} from '../../utils/settings'
 import {RoamNode, Selection} from '../../roam/roam-node'
 import {Roam} from '../../roam/roam'
+console.log('block manipulation!')
 
 export const config: Feature = {
     id: 'block_manipulation',

--- a/src/ts/contentScripts/create-block-demo/index.tsx
+++ b/src/ts/contentScripts/create-block-demo/index.tsx
@@ -1,5 +1,6 @@
 import {getFirstTopLevelBlock} from '../../utils/dom'
 import {Roam} from '../../roam/roam'
+console.log('create-block-demo!')
 
 export const createDemo = async () => {
     await Roam.createBlockAtBottom()

--- a/src/ts/contentScripts/custom-css/index.tsx
+++ b/src/ts/contentScripts/custom-css/index.tsx
@@ -1,6 +1,7 @@
 import {browser} from 'webextension-polyfill-ts'
 import {Feature, Settings} from '../../utils/settings'
 
+console.log('custom css!')
 export const config: Feature = {
     id: 'custom-css',
     name: 'Custom CSS',

--- a/src/ts/contentScripts/dispatcher/index.ts
+++ b/src/ts/contentScripts/dispatcher/index.ts
@@ -1,5 +1,4 @@
 import {browser} from 'webextension-polyfill-ts'
-import {guard, replaceFuzzyDate} from '../fuzzy_date'
 import {createDemo} from '../create-block-demo'
 import {updateShortcuts} from '../shortcuts'
 
@@ -13,14 +12,3 @@ const dispatchMap = new Map([
 ])
 
 browser.runtime.onMessage.addListener(command => dispatchMap.get(command)?.())
-
-/**
- * We use `keypress`, since `keyup` is sometimes firing for individual keys instead of the pressed key 
- * when the guard character is requiring a multi-key stroke.
- *
- * `setTimeout` is used to put the callback to the end of the event queue, 
- * since the input is not yet changed when keypress is firing.
- */
-document.addEventListener('keypress', ev => {
-    if (ev.key === guard) setTimeout(replaceFuzzyDate, 0)
-})

--- a/src/ts/contentScripts/entry/index.ts
+++ b/src/ts/contentScripts/entry/index.ts
@@ -1,0 +1,15 @@
+/**
+ * this is a single entry file for all content scripts to be loaded
+ * nto the page once
+ * any file to be loaded, should be present
+ *  either in /feature.ts (if it's a new feature), or dispatcher/index.ts (it you want to inject globally)
+ */
+
+/**
+ * Use dispatcher for global stuff, like keyboard shortcuts.
+ * Let features handle their own dispatches. This decouples the code too.
+ * Maybe make a seperate observer pattern for the same.
+ */
+
+import '../features'
+import '../dispatcher'

--- a/src/ts/contentScripts/estimates/index.ts
+++ b/src/ts/contentScripts/estimates/index.ts
@@ -2,6 +2,7 @@ import {Feature, Settings, Shortcut, String} from '../../utils/settings'
 import {getActiveEditElement} from '../../utils/dom'
 import {RoamNode} from '../../roam/roam-node'
 import {Roam} from '../../roam/roam'
+console.log('estimates!')
 
 const estimateProperty: String = {
     type: 'string',

--- a/src/ts/contentScripts/features.ts
+++ b/src/ts/contentScripts/features.ts
@@ -10,7 +10,7 @@ import {filterAsync, mapAsync} from '../utils/async'
 
 export const Features = {
     all: prepareSettings([
-        incDec, //prettier
+        incDec, // prettier
         srs,
         blockManipulation,
         estimate,

--- a/src/ts/contentScripts/fuzzy_date/index.ts
+++ b/src/ts/contentScripts/fuzzy_date/index.ts
@@ -33,3 +33,14 @@ export function replaceFuzzyDate() {
         return replaceMode ? newNode.withDate(date) : newNode
     })
 }
+
+/**
+ * We use `keypress`, since `keyup` is sometimes firing for individual keys instead of the pressed key
+ * when the guard character is requiring a multi-key stroke.
+ *
+ * `setTimeout` is used to put the callback to the end of the event queue,
+ * since the input is not yet changed when keypress is firing.
+ */
+document.addEventListener('keypress', ev => {
+    if (ev.key === guard) setTimeout(replaceFuzzyDate, 0)
+})

--- a/src/ts/contentScripts/fuzzy_date/index.ts
+++ b/src/ts/contentScripts/fuzzy_date/index.ts
@@ -5,6 +5,7 @@ import {RoamNode, Selection} from '../../roam/roam-node'
 import {Roam} from '../../roam/roam'
 import {NodeWithDate} from '../../date/withDate'
 
+console.log('fuzzy date')
 export const guard = ';'
 const dateContainerExpr = /;(.{3,}?);/gm
 

--- a/src/ts/contentScripts/inc-dec-value/index.tsx
+++ b/src/ts/contentScripts/inc-dec-value/index.tsx
@@ -2,6 +2,7 @@ import {Feature, Shortcut} from '../../utils/settings'
 import {RoamDate} from '../../date/common'
 import {Roam} from '../../roam/roam'
 import {RoamNode, Selection} from '../../roam/roam-node'
+console.log('inc-dec-value!')
 
 const createModifier = (change: number) => (num: number) => num + change
 

--- a/src/ts/contentScripts/navigation/index.ts
+++ b/src/ts/contentScripts/navigation/index.ts
@@ -1,6 +1,6 @@
 import {Feature, Shortcut} from '../../utils/settings'
 import {Navigation} from '../../roam/navigation'
-
+console.log('navigation!')
 export const config: Feature = {
     id: 'navigation',
     name: 'Navigation',

--- a/src/ts/contentScripts/shortcuts/index.tsx
+++ b/src/ts/contentScripts/shortcuts/index.tsx
@@ -2,6 +2,7 @@ import {Features} from '../features'
 import {configure, GlobalHotKeys} from 'react-hotkeys'
 import React from 'react'
 import ReactDOM from 'react-dom'
+console.log('shortcuts!')
 
 configure({
     ignoreTags: [],

--- a/src/ts/contentScripts/srs/index.tsx
+++ b/src/ts/contentScripts/srs/index.tsx
@@ -4,6 +4,7 @@ import {SM2Node} from '../../srs/SM2Node'
 import {AnkiScheduler} from '../../srs/AnkiScheduler'
 import {RoamNode} from '../../roam/roam-node'
 import {Roam} from '../../roam/roam'
+console.log('srss!')
 
 export const config: Feature = {
     id: 'srs',


### PR DESCRIPTION
This attempts to fix the problem discussed here: https://github.com/roam-unofficial/roam-toolkit/pull/52#issuecomment-629761632

Root cause: We were loading all contentScripts more than one time (some cases - 3) - once in either `/dispatcher` or `/features` (or both), and again by their own separate entry in `content_scripts`. 

To fix this, 
1. we need a single entry point (`entry.js`). Only that should be added in `content_scripts`. This is the quickest fix, without changing too much of the code structure, and has the option of refactoring in the future
    - (except no global `dispatcher` - which did seem like an anti-pattern anyway - why does. 
       dispatcher care about something needed only by one script?).
   -   I have implemented this & also added logs statements to verify the scripts loading.

2. or, we need logically separated entry points.  (needs refactor)
    To achieve this, we would need some decoupling with the current `dispatcher` -- which we 
    can call `keyboardShortcutsDispatcher`.


Note: A file should only be present in only one of the entry points (in `/entry`): either `/dispatcher`, or `/features`. If not, it will get loaded multiple times.

Feel free to make changes to this as required @Stvad 