### PR TITLE
Vim Mode 1 - Allow absolute imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,8 +40,13 @@
 
         /* Module Resolution Options */
         "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-        // "baseUrl": "./",                      	/* Base directory to resolve non-absolute module names. */
-        // "paths": {},                          	/* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+        "baseUrl": "./",                    	    /* Base directory to resolve non-absolute module names. */
+        "paths": {
+            // Enable absolute imports
+            "src/*": [
+                "./src/ts/*"
+            ]
+        },                          	            /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         // "rootDirs": [],                       	/* List of root folders whose combined content represents the structure of the project at runtime. */
         // "typeRoots": [],                      	/* List of folders to include type definitions from. */
         "types": ["react", "jest", "chrome"] /* Type declaration files to be included in compilation. */,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,10 @@ module.exports = {
     },
     resolve: {
         extensions: ['.js', '.ts', '.tsx', '.json'],
+        alias: {
+            // Enable absolute imports
+            src: path.resolve(__dirname, 'src/ts/')
+        }
     },
     module: {
         rules: [{test: /\.(js|ts|tsx)?$/, loader: 'awesome-typescript-loader', exclude: /node_modules/}],


### PR DESCRIPTION
This is part of a larger change to support vim style navigation (#63)

I think absolute imports are easier to read in some cases, since otherwise the import would be like something like `../../../../core/roam`.

I've been using absolute imports when reusing generic utilities, but using relative imports if I'm importing something in the same folder, since the import would just be `./my-package-private-module`