### PR TITLE
Fix tests by updating import paths

### DIFF
--- a/tests/ts/components/styles/themes/index.test.ts
+++ b/tests/ts/components/styles/themes/index.test.ts
@@ -1,4 +1,4 @@
-import { themes } from '../../../../../src/ts/components/styles/themes';
+import { themes } from 'src/components/styles/themes';
 
 describe('Testing themes configuration', () => {
 	test('Theme object containes a dark and a light property', () => {

--- a/tests/ts/core/roam/date/withDate.test.ts
+++ b/tests/ts/core/roam/date/withDate.test.ts
@@ -1,5 +1,5 @@
-import {NodeWithDate} from '../../../../../src/ts/core/roam/date/withDate'
-import {RoamDate} from '../../../../../src/ts/core/roam/date'
+import {NodeWithDate} from 'src/core/roam/date/withDate'
+import {RoamDate} from 'src/core/roam/date'
 
 
 describe(NodeWithDate, () => {

--- a/tests/ts/core/roam/roam-node.test.ts
+++ b/tests/ts/core/roam/roam-node.test.ts
@@ -1,4 +1,4 @@
-import {RoamNode, Selection} from '../../../../src/ts/core/roam/roam-node';
+import {RoamNode, Selection} from 'src/core/roam/roam-node';
 
 describe(RoamNode, () => {
     const propertyName = 'inline_property';

--- a/tests/ts/core/srs/AnkiScheduler.test.ts
+++ b/tests/ts/core/srs/AnkiScheduler.test.ts
@@ -1,6 +1,6 @@
-import {SRSSignal} from '../../../../src/ts/core/srs/scheduler';
-import {SM2Node} from '../../../../src/ts/core/srs/SM2Node';
-import {AnkiScheduler} from '../../../../src/ts/core/srs/AnkiScheduler';
+import {SRSSignal} from 'src/core/srs/scheduler';
+import {SM2Node} from 'src/core/srs/SM2Node';
+import {AnkiScheduler} from 'src/core/srs/AnkiScheduler';
 
 describe(AnkiScheduler, () => {
     const subject = new AnkiScheduler()


### PR DESCRIPTION
Accidentally broke tests with https://github.com/roam-unofficial/roam-toolkit/pull/93, fixed by updating the imports