### PR TITLE
Swich the inline property to be surrounded by {} instead of [[]]

### DIFF
--- a/src/ts/core/roam/roam-node.ts
+++ b/src/ts/core/roam/roam-node.ts
@@ -33,11 +33,16 @@ export class RoamNode {
     }
 
     static createInlineProperty(name: string, value: string) {
-        return `[[[[${name}]]:${value}]]`
+        return `{[[${name}]]:${value}}`
     }
 
     static getInlinePropertyMatcher(name: string) {
-        return new RegExp(`\\[\\[\\[\\[${name}]]::?(.*?)]]`, 'g')
+        /**
+         * This has a bunch of things for backward compatibility:
+         * - Potentially allowing double colon `::` between name and value
+         * - Accepting both `{}` and `[[]]` wrapped properties
+         */
+        return new RegExp(`(?:\\[\\[|{)\\[\\[${name}]]::?(.*?)(?:]]|})`, 'g')
     }
 }
 


### PR DESCRIPTION
So for SRS it'd go from `[[[[interval]]:3]]` to `{[[interval]]:3}`