### PR TITLE
Save the selected block's index, instead of it's id

### DIFF
--- a/src/ts/core/features/vim-mode/commands/clipboard-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/clipboard-commands.ts
@@ -35,9 +35,9 @@ const copySelectedBlock = async (mode: Mode) => {
     await returnToNormalMode()
 }
 
-const copySelectedBlockReference = () => copyBlockReference(RoamPanel.selected().selectedBlockId)
+const copySelectedBlockReference = () => copyBlockReference(RoamPanel.selected().selectedBlock().id)
 
-const copySelectedBlockEmbed = () => copyBlockEmbed(RoamPanel.selected().selectedBlockId)
+const copySelectedBlockEmbed = () => copyBlockEmbed(RoamPanel.selected().selectedBlock().id)
 
 const enterOrCutInVisualMode = async (mode: Mode) => {
     if (mode === Mode.NORMAL) {

--- a/src/ts/core/features/vim-mode/roam/roam-block.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-block.ts
@@ -9,14 +9,14 @@ export type BlockElement = HTMLElement
  * The generically reusable parts of this should probably move to core/roam
  */
 export class RoamBlock {
-    private blockId: BlockId
+    element: BlockElement
 
-    constructor(blockId: BlockId) {
-        this.blockId = blockId
+    constructor(element: BlockElement) {
+        this.element = element
     }
 
-    get element(): BlockElement {
-        return assumeExists(document.getElementById(this.blockId))
+    get id(): string {
+        return this.element.id
     }
 
     async edit() {
@@ -28,7 +28,7 @@ export class RoamBlock {
     }
 
     static get(blockId: BlockId): RoamBlock {
-        return new RoamBlock(blockId)
+        return new RoamBlock(assumeExists(document.getElementById(blockId)))
     }
 
     static selected(): RoamBlock {

--- a/src/ts/core/features/vim-mode/roam/roam-event.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-event.ts
@@ -48,7 +48,7 @@ export const RoamEvent = {
         return onBlockEvent('focusout', element => {
             // Wait for the text area to transform back into a regular block
             const container = assumeExists(element.closest(Selectors.blockContainer)) as HTMLElement
-            waitForSelectorToExist(`${Selectors.block}#${element.id}`, container).then(handler)
+            waitForSelectorToExist(`${Selectors.block}#${Selectors.escapeHtmlId(element.id)}`, container).then(handler)
         })
     },
 
@@ -56,7 +56,7 @@ export const RoamEvent = {
         // Only the content changes when switching between pages
         let stopObservingContent = onSelectorChange(Selectors.mainContent, handler)
         // The main panel changes when switching between daily notes and regular pages
-        let stopObservingMainPanel = onSelectorChange(Selectors.mainPanel, () => {
+        const stopObservingMainPanel = onSelectorChange(Selectors.mainPanel, () => {
             handler()
             stopObservingContent()
             stopObservingContent = onSelectorChange(Selectors.mainContent, handler)

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -1,6 +1,7 @@
 export const Selectors = {
     link: '.rm-page-ref',
     block: '.roam-block',
+    blockInput: '.rm-block-input',
     blockContainer: '.roam-block-container',
     blockReference: '.rm-block-ref',
     title: '.rm-title-display',
@@ -22,4 +23,10 @@ export const Selectors = {
     externalLink: 'a',
     referenceItem: '.rm-reference-item',
     breadcrumbsContainer: '.zoom-mentions-view',
+
+    /**
+     * Blocks in mentions may contain your actual email address, which messes up querySelector, unless
+     * special characters are escaped.
+     */
+    escapeHtmlId: (htmlId: string) => htmlId.replace('.', '\\.').replace('@', '\\@'),
 }


### PR DESCRIPTION
This fixes #100.

It also simplifies the relative block navigation, because the block index is directly manipulated as the source of truth, rather than converting `BlockId` => `BlockIndex` => back to `BlockId`

Here's a demo of preserving position with SRS shortcuts:

![relativeBlocks](https://user-images.githubusercontent.com/1150079/86880843-2965e500-c0a2-11ea-9aee-308dad518d1e.gif)

This also fixes an issue where the selection is lost when editing blocks inside of references.