### PR TITLE
Override manifest.json in both watch and development mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ const addUnsafeEvalToManifestPlugin = new ReplaceInFileWebpackPlugin([
     },
 ])
 
-const developmentModeManifestPlugin = nodeEnv === 'development' ? addUnsafeEvalToManifestPlugin : noopPlugin
+const developmentModeManifestPlugin = nodeEnv === 'production' ? noopPlugin : addUnsafeEvalToManifestPlugin
 
 module.exports = {
     watch: nodeEnv === 'watch',


### PR DESCRIPTION
Fixes an issue in https://github.com/roam-unofficial/roam-toolkit/pull/109

Previously, the `manifest.json` was only overridden when running `npm run dev`, but upon running `npm run watch`, `manifest.json` would revert to it's original state.

This makes it so the manifest file is tweaked in both development and watch modes