### PR TITLE
Fix folding within references

### DIFF
--- a/src/ts/core/common/mouse.ts
+++ b/src/ts/core/common/mouse.ts
@@ -11,6 +11,7 @@ export const Mouse = {
     },
     hover(element: HTMLElement, delayOverride: number = 0) {
         element.dispatchEvent(getMouseEvent('mouseover', 1))
+        element.dispatchEvent(getMouseEvent('mousemove', 1))
         return delay(delayOverride || this.BASE_DELAY)
     },
     leftClick(element: HTMLElement, shiftKey: boolean = false, additionalDelay: number = 0) {


### PR DESCRIPTION
For some reason, the fold caret inside of references needs a mouse **move**, rather than a mouse **over**