### PR TITLE
Fix folding headings

### DIFF
--- a/src/ts/core/roam/roam.ts
+++ b/src/ts/core/roam/roam.ts
@@ -140,10 +140,16 @@ export const Roam = {
     },
 
     async toggleFoldBlock(block: HTMLElement) {
-        const foldButton = assumeExists(
-            assumeExists(block.parentElement).querySelector(Selectors.foldButton)
-        ) as HTMLElement
+        const foldButton = nearestFoldButton(block)
         await Mouse.hover(foldButton)
         await Mouse.leftClick(foldButton)
     },
+}
+
+const nearestFoldButton = (element: HTMLElement): HTMLElement => {
+    const foldButton = element.querySelector(Selectors.foldButton) as HTMLElement
+    if (foldButton) {
+        return foldButton
+    }
+    return nearestFoldButton(assumeExists(element.parentElement))
 }


### PR DESCRIPTION
Closes https://github.com/roam-unofficial/roam-toolkit/issues/125

The issue was that normal blocks are siblings of the fold caret, but headings are _children_ of siblings of the fold caret

![fold headings](https://user-images.githubusercontent.com/1150079/87208843-bd16fb80-c2c4-11ea-89cf-8e28f3e85328.gif)
