### PR TITLE
Select first block when switching pages

### DIFF
--- a/src/ts/core/features/vim-mode/commands/navigation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/navigation-commands.ts
@@ -2,23 +2,13 @@ import {nimap, nmap, nvmap, RoamVim} from 'src/core/features/vim-mode/vim'
 import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
 import {closePageReferenceView, expandLastBreadcrumb} from 'src/core/roam/references'
 
-const selectFirstBlock = () => {
-    const panel = RoamPanel.selected()
-    panel.selectBlock(panel.firstBlock().id)
-}
-
-const selectLastBlock = () => {
-    const panel = RoamPanel.selected()
-    panel.selectBlock(panel.lastBlock().id)
-}
-
 export const NavigationCommands = [
     nvmap('k', 'Select Block Up', () => RoamVim.jumpBlocksInFocusedPanel(-1)),
     nvmap('j', 'Select Block Down', () => RoamVim.jumpBlocksInFocusedPanel(1)),
     nmap('shift+h', 'Select First Visible Block', () => RoamPanel.selected().selectFirstVisibleBlock()),
     nmap('shift+l', 'Select Last Visible Block', () => RoamPanel.selected().selectLastVisibleBlock()),
-    nmap('g g', 'Select First Block', selectFirstBlock),
-    nmap('shift+g', 'Select Last Block', selectLastBlock),
+    nmap('g g', 'Select First Block', () => RoamPanel.selected().selectFirstBlock()),
+    nmap('shift+g', 'Select Last Block', () => RoamPanel.selected().selectLastBlock()),
     nmap('ctrl+u', 'Select Many Blocks Up', () => RoamVim.jumpBlocksInFocusedPanel(-8)),
     nmap('ctrl+d', 'Select Many Blocks Down', () => RoamVim.jumpBlocksInFocusedPanel(8)),
     nvmap('ctrl+y', 'Scroll Up', () => RoamPanel.selected().scrollAndReselectBlockToStayVisible(-50)),

--- a/src/ts/core/features/vim-mode/roam/roam-panel.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-panel.ts
@@ -71,7 +71,6 @@ export class RoamPanel {
             // Fallback to the the position of the last selected block
             const blocks = this.blocks()
             this.blockIndex = clamp(this.blockIndex, 0, blocks.length - 1)
-            console.log(this.blockIndex, blocks[this.blockIndex])
             this.selectBlock(blocks[this.blockIndex].id)
         }
 
@@ -91,6 +90,14 @@ export class RoamPanel {
     selectRelativeBlock(blocksToJump: number) {
         const block = this.selectedBlock().element
         this.selectBlock(this.relativeBlockId(block.id, blocksToJump))
+    }
+
+    selectFirstBlock() {
+        this.selectBlock(this.firstBlock().id)
+    }
+
+    selectLastBlock() {
+        this.selectBlock(this.lastBlock().id)
     }
 
     selectLastVisibleBlock() {

--- a/src/ts/core/features/vim-mode/vim-init.ts
+++ b/src/ts/core/features/vim-mode/vim-init.ts
@@ -47,6 +47,7 @@ export const startVimMode = async () => {
         // Select first block when switching pages
         RoamEvent.onChangePage(() => {
             RoamPanel.updateSidePanels()
+            RoamPanel.mainPanel().selectFirstBlock()
             updateVimView()
         }),
     ]


### PR DESCRIPTION
Turns out it's actually pretty easy to select the first block, the `onChangePage` event works fine