### PR TITLE
Shortcuts to open pages in linked references

### DIFF
--- a/src/ts/core/features/vim-mode/commands/navigation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/navigation-commands.ts
@@ -1,6 +1,6 @@
 import {nimap, nmap, nvmap, RoamVim} from 'src/core/features/vim-mode/vim'
 import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
-import {closePageReferenceView, expandLastBreadcrumb} from 'src/core/roam/references'
+import {closePageReferenceView, expandLastBreadcrumb, openParentPage} from 'src/core/roam/references'
 
 export const NavigationCommands = [
     nvmap('k', 'Select Block Up', () => RoamVim.jumpBlocksInFocusedPanel(-1)),
@@ -16,4 +16,6 @@ export const NavigationCommands = [
     nvmap('ctrl+e', 'Scroll Down', () => RoamPanel.selected().scrollAndReselectBlockToStayVisible(50)),
     nimap('alt+z', 'Expand Last Reference Breadcrumb', expandLastBreadcrumb),
     nmap('shift+z', 'Collapse the view for the page in references (or query) section', closePageReferenceView),
+    nmap('1', 'Open parent page', () => openParentPage()),
+    nmap('shift+1', 'Open parent page in sidebar', () => openParentPage(true)),
 ]

--- a/src/ts/core/roam/references.ts
+++ b/src/ts/core/roam/references.ts
@@ -15,3 +15,11 @@ export const closePageReferenceView = () => {
 
     if (caretButton) Mouse.leftClick(caretButton as HTMLElement)
 }
+
+export const openParentPage = (shiftKey: boolean = false) => {
+    const referenceCard = RoamBlock.selected().element?.closest(Selectors.pageReferenceItem)
+    const referenceCardLink = referenceCard?.querySelector(Selectors.pageReferenceLink) as HTMLElement
+    if (referenceCardLink) {
+        Mouse.leftClick(referenceCardLink, shiftKey)
+    }
+}

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -24,6 +24,7 @@ export const Selectors = {
     referenceItem: '.rm-reference-item',
     breadcrumbsContainer: '.zoom-mentions-view',
     pageReferenceItem: '.rm-ref-page-view',
+    pageReferenceLink: '.rm-ref-page-view-title a span',
     caretButton: '.rm-caret',
     filterButton: '.bp3-icon.bp3-icon-filter',
 


### PR DESCRIPTION
This allows opening the parent page when selecting a block in linked references

![opening linked reference pages](https://user-images.githubusercontent.com/1150079/88440670-89a79700-cdc3-11ea-8183-310481a2d37e.gif)

Not sure what the most intuitive shortcut would be, so I just picked `1`