### PR TITLE
Shortcut to insert random page, open random pages in the sidebar

### DIFF
--- a/src/ts/core/features/index.ts
+++ b/src/ts/core/features/index.ts
@@ -11,6 +11,7 @@ import {config as navigation} from './navigation'
 import {config as livePreview} from './livePreview'
 import {config as dateTitle} from './day-title'
 import {config as fuzzyDate} from './fuzzy_date'
+import {config as randomPage} from './random-page'
 import {filterAsync, mapAsync} from '../common/async'
 import {Handler} from 'src/core/react-hotkeys/key-handler'
 import {KeySequenceString} from 'src/core/react-hotkeys/key-sequence'
@@ -26,6 +27,7 @@ export const Features = {
         dateTitle,
         fuzzyDate,
         livePreview,
+        randomPage,
     ]),
 
     isActive: Settings.isActive,

--- a/src/ts/core/features/random-page.ts
+++ b/src/ts/core/features/random-page.ts
@@ -1,27 +1,34 @@
+import {random} from 'lodash'
 import {Feature, Settings, Shortcut} from '../settings'
 import {RoamDb} from 'src/core/roam/roam-db'
 import {Roam} from 'src/core/roam/roam'
+import {Keyboard} from 'src/core/common/keyboard'
+import {KEY_TO_CODE} from 'src/core/common/keycodes'
 
-const DEFAULT_EXCLUDE_PATTERN = ', 2019|, 2020|\\[\\[interval|\\[\\[factor'
+const DEFAULT_EXCLUDE_PATTERN = ', 20dd$|\\[\\[interval|\\[\\[factor'
 
-const insertRandomLink = async (): Promise<string> => {
-    console.log('INSERT')
+const getRandomPageName = async () => {
     const excludePattern = await Settings.get('random-page', 'random-page-exclude', DEFAULT_EXCLUDE_PATTERN)
     const excludeRegex = new RegExp(excludePattern)
     const pageNames = RoamDb.getAllPages()
         .filter(({name}) => !name.match(excludeRegex))
         .map(({name}) => name)
-    const pageName = pageNames[Math.floor(pageNames.length * Math.random())]
+    return pageNames[random(pageNames.length - 1)]
+}
+
+const insertRandomLink = async (): Promise<string> => {
+    const pageName = await getRandomPageName()
     Roam.appendText(`[[${pageName}]]\n`)
     return pageName
 }
 
 const openRandomPage = async () => {
-    console.log('OPEN')
     const insertedPage = await insertRandomLink()
     await Roam.moveCursorToSearchTerm(insertedPage)
-    await Roam.followLinkUnderCursor()
+    await followLinkUnderCursor()
 }
+
+const followLinkUnderCursor = () => Keyboard.simulateKey(KEY_TO_CODE.o, 0, {key: 'o', shiftKey: true, ctrlKey: true})
 
 export const config: Feature = {
     id: 'random-page',
@@ -32,7 +39,7 @@ export const config: Feature = {
             type: 'shortcut',
             id: 'insert-random-page',
             label: 'Insert Random Page',
-            initValue: 'ctrl+shift+?',
+            initValue: 'ctrl+shift+/',
             placeholder: '',
             onPress: insertRandomLink,
         } as Shortcut,
@@ -40,7 +47,7 @@ export const config: Feature = {
             type: 'shortcut',
             id: 'open-random-page-in-sidebar',
             label: 'Open Random Page in Sidebar',
-            initValue: 'ctrl+command+shift+?',
+            initValue: 'ctrl+command+shift+/',
             placeholder: '',
             onPress: openRandomPage,
         } as Shortcut,

--- a/src/ts/core/features/random-page.ts
+++ b/src/ts/core/features/random-page.ts
@@ -1,0 +1,54 @@
+import {Feature, Settings, Shortcut} from '../settings'
+import {RoamDb} from 'src/core/roam/roam-db'
+import {Roam} from 'src/core/roam/roam'
+
+const DEFAULT_EXCLUDE_PATTERN = ', 2019|, 2020|\\[\\[interval|\\[\\[factor'
+
+const insertRandomLink = async (): Promise<string> => {
+    console.log('INSERT')
+    const excludePattern = await Settings.get('random-page', 'random-page-exclude', DEFAULT_EXCLUDE_PATTERN)
+    const excludeRegex = new RegExp(excludePattern)
+    const pageNames = RoamDb.getAllPages()
+        .filter(({name}) => !name.match(excludeRegex))
+        .map(({name}) => name)
+    const pageName = pageNames[Math.floor(pageNames.length * Math.random())]
+    Roam.appendText(`[[${pageName}]]\n`)
+    return pageName
+}
+
+const openRandomPage = async () => {
+    console.log('OPEN')
+    const insertedPage = await insertRandomLink()
+    await Roam.moveCursorToSearchTerm(insertedPage)
+    await Roam.followLinkUnderCursor()
+}
+
+export const config: Feature = {
+    id: 'random-page',
+    name: 'Random Page',
+    enabledByDefault: true,
+    settings: [
+        {
+            type: 'shortcut',
+            id: 'insert-random-page',
+            label: 'Insert Random Page',
+            initValue: 'ctrl+shift+?',
+            placeholder: '',
+            onPress: insertRandomLink,
+        } as Shortcut,
+        {
+            type: 'shortcut',
+            id: 'open-random-page-in-sidebar',
+            label: 'Open Random Page in Sidebar',
+            initValue: 'ctrl+command+shift+?',
+            placeholder: '',
+            onPress: openRandomPage,
+        } as Shortcut,
+        {
+            type: 'string',
+            id: 'random-page-exclude',
+            label: 'Ignore Pages Regex',
+            initValue: DEFAULT_EXCLUDE_PATTERN,
+        },
+    ],
+}

--- a/src/ts/core/features/vim-mode/commands/insert-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/insert-commands.ts
@@ -10,12 +10,12 @@ export const insertBlockAfter = async () => {
 
 const editBlock = async () => {
     await Roam.activateBlock(RoamBlock.selected().element)
-    Roam.moveCursorToStart()
+    await Roam.moveCursorToStart()
 }
 
 const editBlockFromEnd = async () => {
     await Roam.activateBlock(RoamBlock.selected().element)
-    Roam.moveCursorToEnd()
+    await Roam.moveCursorToEnd()
 }
 
 const insertBlockBefore = async () => {

--- a/src/ts/core/roam/roam-db.ts
+++ b/src/ts/core/roam/roam-db.ts
@@ -12,6 +12,9 @@ export const RoamDb = {
     },
 
     query(query: string, ...params: any[]) {
+        console.log('Executing Roam DB query', query)
+        console.log('Query params', params)
+
         // @ts-ignore
         return runInPageContext((...args: any[]) => window.roamAlphaAPI.q(...args), query, ...params)
     },

--- a/src/ts/core/roam/roam-db.ts
+++ b/src/ts/core/roam/roam-db.ts
@@ -1,5 +1,10 @@
 import {runInPageContext} from '../common/browser'
 
+type RoamPage = {
+    uid: string
+    name: string
+}
+
 export const RoamDb = {
     getBlockById(dbId: number) {
         // @ts-ignore
@@ -7,9 +12,6 @@ export const RoamDb = {
     },
 
     query(query: string, ...params: any[]) {
-        console.log('Executing Roam DB query', query)
-        console.log('Query params', params)
-
         // @ts-ignore
         return runInPageContext((...args: any[]) => window.roamAlphaAPI.q(...args), query, ...params)
     },
@@ -27,5 +29,11 @@ export const RoamDb = {
 
     getBlockByUid(uid: string) {
         return this.queryFirst('[:find ?e :in $ ?a :where [?e :block/uid ?a]]', uid)
+    },
+
+    getAllPages(): RoamPage[] {
+        return this.query(
+            '[:find ?uid ?title :where [?page :node/title ?title] [?page :block/uid ?uid]]'
+        ).map(([uid, name]: [string, string]) => ({uid, name}))
     },
 }

--- a/src/ts/core/roam/roam-node.ts
+++ b/src/ts/core/roam/roam-node.ts
@@ -16,6 +16,10 @@ export class RoamNode {
     withCursorAtTheStart = () => this.withSelection(new Selection(0, 0))
     withCursorAtTheEnd = () => this.withSelection(new Selection(this.text.length, this.text.length))
 
+    withCursorAtSearchTerm = (searchTerm: string) => {
+        const indexOfSearchTerm = this.text.indexOf(searchTerm)
+        return this.withSelection(new Selection(indexOfSearchTerm, indexOfSearchTerm))
+    }
     withSelection = (selection: Selection) => new RoamNode(this.text, selection)
 
     getInlineProperty(name: string) {

--- a/src/ts/core/roam/roam.ts
+++ b/src/ts/core/roam/roam.ts
@@ -6,7 +6,6 @@ import {getActiveEditElement, getFirstTopLevelBlock, getInputEvent, getLastTopLe
 import {Keyboard} from '../common/keyboard'
 import {Mouse} from '../common/mouse'
 import {delay} from 'src/core/common/async'
-import {KEY_TO_CODE} from 'src/core/common/keycodes'
 
 export const Roam = {
     async save(roamNode: RoamNode): Promise<void> {
@@ -155,10 +154,6 @@ export const Roam = {
         const foldButton = nearestFoldButton(block)
         await Mouse.hover(foldButton)
         await Mouse.leftClick(foldButton)
-    },
-
-    async followLinkUnderCursor(shiftKey: boolean = true) {
-        await Keyboard.simulateKey(KEY_TO_CODE.o, 0, {key: 'o', shiftKey, ctrlKey: true})
     },
 }
 


### PR DESCRIPTION
[Demo Video](https://www.youtube.com/watch?v=1mofhCa776U)

## Features
* `ctrl+shift+?` inserts a random link in the currently focused block
* `ctrl+command+shift+?` inserts a link, and then opens in the sidebar
* Also provides a regex to exclude pages such as SRS metadata, and Daily Notes

## Other Changes
This also adds the `Roam.moveCursorToSearchTerm` helper, which might be helpful for navigating the cursor around in a block.

Also, I think I finally figured out why the `insert block after` shortcut was unreliable for me in vim mode. It's because when `Roam.save` triggers the "input" event, it resets the cursor selection. I delayed the cursor selection until after the input event is handled. Otherwise, the selection sometimes doesn't get applied.