### PR TITLE
Fix folding blocks in Vim Mode. Also add shortcut to open mentions

### DIFF
--- a/src/ts/core/features/vim-mode/commands/navigation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/navigation-commands.ts
@@ -1,6 +1,6 @@
 import {nimap, nmap, nvmap, RoamVim} from 'src/core/features/vim-mode/vim'
 import {RoamPanel} from 'src/core/features/vim-mode/roam/roam-panel'
-import {closePageReferenceView, expandLastBreadcrumb, openParentPage} from 'src/core/roam/references'
+import {closePageReferenceView, expandLastBreadcrumb, openMentions, openParentPage} from 'src/core/roam/references'
 
 export const NavigationCommands = [
     nvmap('k', 'Select Block Up', () => RoamVim.jumpBlocksInFocusedPanel(-1)),
@@ -18,4 +18,5 @@ export const NavigationCommands = [
     nmap('shift+z', 'Collapse the view for the page in references (or query) section', closePageReferenceView),
     nmap('1', 'Open parent page', () => openParentPage()),
     nmap('shift+1', 'Open parent page in sidebar', () => openParentPage(true)),
+    nmap('2', 'Open mentions', () => openMentions()),
 ]

--- a/src/ts/core/features/vim-mode/commands/navigation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/navigation-commands.ts
@@ -19,4 +19,5 @@ export const NavigationCommands = [
     nmap('1', 'Open parent page', () => openParentPage()),
     nmap('shift+1', 'Open parent page in sidebar', () => openParentPage(true)),
     nmap('2', 'Open mentions', () => openMentions()),
+    nmap('shift+2', 'Open mentions in sidebar', () => openMentions(true)),
 ]

--- a/src/ts/core/roam/references.ts
+++ b/src/ts/core/roam/references.ts
@@ -11,9 +11,9 @@ export const expandLastBreadcrumb = () => {
 
 export const closePageReferenceView = () => {
     const referenceItem = RoamBlock.selected().element?.closest(Selectors.pageReferenceItem)
-    const caretButton = referenceItem?.querySelector(Selectors.caretButton)
+    const foldButton = referenceItem?.querySelector(Selectors.foldButton)
 
-    if (caretButton) Mouse.leftClick(caretButton as HTMLElement)
+    if (foldButton) Mouse.leftClick(foldButton as HTMLElement)
 }
 
 const parentPageLink = (blockElement: BlockElement | null): HTMLElement | null => {

--- a/src/ts/core/roam/references.ts
+++ b/src/ts/core/roam/references.ts
@@ -44,3 +44,22 @@ export const openParentPage = (shiftKey: boolean = false) => {
 
     Mouse.leftClick(parentLink, shiftKey)
 }
+
+const getMentionsButton = (blockElement: BlockElement | null): HTMLElement | null => {
+    const blockMentionsButton = blockElement
+        ?.closest(Selectors.blockBulletView)
+        ?.querySelector('.block-ref-count-button')
+    if (blockMentionsButton) {
+        return blockMentionsButton as HTMLElement
+    }
+
+    const sidePanel = blockElement?.closest(Selectors.sidebarPage)
+    return sidePanel?.querySelector('button.bp3-button') as HTMLElement
+}
+
+export const openMentions = () => {
+    const mentionsButton = getMentionsButton(RoamBlock.selected().element)
+    if (mentionsButton) {
+        Mouse.leftClick(mentionsButton)
+    }
+}

--- a/src/ts/core/roam/references.ts
+++ b/src/ts/core/roam/references.ts
@@ -57,9 +57,9 @@ const getMentionsButton = (blockElement: BlockElement | null): HTMLElement | nul
     return sidePanel?.querySelector('button.bp3-button') as HTMLElement
 }
 
-export const openMentions = () => {
+export const openMentions = (shiftKey: boolean = false) => {
     const mentionsButton = getMentionsButton(RoamBlock.selected().element)
     if (mentionsButton) {
-        Mouse.leftClick(mentionsButton)
+        Mouse.leftClick(mentionsButton, shiftKey)
     }
 }

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -4,6 +4,7 @@ export const Selectors = {
     blockInput: '.rm-block-input',
     blockContainer: '.roam-block-container',
     blockReference: '.rm-block-ref',
+    blockBulletView: '.block-bullet-view',
     title: '.rm-title-display',
 
     mainContent: '.roam-article',

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -16,7 +16,7 @@ export const Selectors = {
 
     leftPanel: '.roam-sidebar-container',
 
-    foldButton: '.block-expand',
+    foldButton: '.rm-caret',
     highlight: '.block-highlight-blue',
     button: '.bp3-button',
     closeButton: '.bp3-icon-cross',
@@ -27,7 +27,6 @@ export const Selectors = {
     breadcrumbsContainer: '.zoom-mentions-view',
     pageReferenceItem: '.rm-ref-page-view',
     pageReferenceLink: '.rm-ref-page-view-title a span',
-    caretButton: '.rm-caret',
     filterButton: '.bp3-icon.bp3-icon-filter',
 
     /**


### PR DESCRIPTION
This fixes https://github.com/roam-unofficial/roam-toolkit/issues/166

It also adds a shortcut to open mentions:

If the block has mentions, this opens the block's mentions

![open mentions](https://user-images.githubusercontent.com/1150079/95773102-b22c8800-0c72-11eb-8aca-b8272ca8c51c.gif)

If the block has no mentions, this open's the page's mentions

![Mentions Page](https://user-images.githubusercontent.com/1150079/95773547-86f66880-0c73-11eb-9f8b-51a18c64bd28.gif)

So this is kind of like "open the mentions for whatever is selected"
