### PR TITLE
Fix navigating between daily notes in vim mode

### DIFF
--- a/src/ts/core/features/vim-mode/roam/roam-event.ts
+++ b/src/ts/core/features/vim-mode/roam/roam-event.ts
@@ -54,17 +54,27 @@ export const RoamEvent = {
 
     onChangePage(handler: () => void): DisconnectFn {
         // Only the content changes when switching between pages
-        let stopObservingContent = onSelectorChange(Selectors.mainContent, handler)
-        // The main panel changes when switching between daily notes and regular pages
-        const stopObservingMainPanel = onSelectorChange(Selectors.mainPanel, () => {
-            handler()
+        let stopObservingContent = () => {}
+        const reobserveContent = () => {
             stopObservingContent()
             stopObservingContent = onSelectorChange(Selectors.mainContent, handler)
-        })
+        }
+        // The main panel changes when switching between daily notes and regular pages
+        let stopObservingMain = () => {}
+        const reobserveMain = () => {
+            stopObservingMain()
+            stopObservingMain = onSelectorChange(Selectors.main, () => {
+                reobserveContent()
+                handler()
+            })
+        }
+
+        reobserveContent()
+        reobserveMain()
 
         return () => {
             stopObservingContent()
-            stopObservingMainPanel()
+            stopObservingMain()
         }
     },
 }

--- a/src/ts/core/roam/selectors.ts
+++ b/src/ts/core/roam/selectors.ts
@@ -7,6 +7,7 @@ export const Selectors = {
     blockBulletView: '.block-bullet-view',
     title: '.rm-title-display',
 
+    main: '.roam-main',
     mainContent: '.roam-article',
     mainPanel: '.roam-body-main',
 


### PR DESCRIPTION
Fixes #173 

Previously, Roam's structure was:

```
`roam-main`
-- `roam-body-main` (observe content from here)
---- `roam-article` <- changes when navigating to/from daily notes
------ `div` <- changes when navigating between pages 
```

Now, Roam's structure is:

```
`roam-main`
-- `roam-body-main` <- changes when navigating to/from daily notes (destroying content observer)
---- `roam-article`
------ `div` <- changes when navigating between pages 
```

To avoid destroying the content observer, we move the observer one level up:

```
`roam-main` (observe content from here)
-- `roam-body-main` <- changes when navigating to/from daily notes (destroying content observer)
---- `roam-article`
------ `div` <- changes when navigating between pages 
```