### PR TITLE
Allow opening mentions of a link with ctrl+shift+hint

### DIFF
--- a/src/ts/core/common/mouse.ts
+++ b/src/ts/core/common/mouse.ts
@@ -1,11 +1,22 @@
 import {delay} from './async'
 
+type Modifiers = {
+    shiftKey?: boolean,
+    metaKey?: boolean,
+    ctrlKey?: boolean,
+}
+
 export const Mouse = {
     BASE_DELAY: 20,
-    simulateClick(buttons: number, element: HTMLElement, shiftKey: boolean = false, delayOverride: number = 0) {
+    simulateClick(
+        buttons: number,
+        element: HTMLElement,
+        modifiers: Modifiers = {},
+        delayOverride: number = 0,
+    ) {
         const mouseClickEvents = ['mousedown', 'click', 'mouseup']
         mouseClickEvents.forEach(mouseEventType => {
-            element.dispatchEvent(getMouseEvent(mouseEventType, buttons, shiftKey))
+            element.dispatchEvent(getMouseEvent(mouseEventType, buttons, modifiers))
         })
         return delay(delayOverride || this.BASE_DELAY)
     },
@@ -14,14 +25,24 @@ export const Mouse = {
         element.dispatchEvent(getMouseEvent('mousemove', 1))
         return delay(delayOverride || this.BASE_DELAY)
     },
-    leftClick(element: HTMLElement, shiftKey: boolean = false, additionalDelay: number = 0) {
-        return this.simulateClick(1, element, shiftKey, additionalDelay)
+    leftClick(
+        element: HTMLElement,
+        modifiers: Modifiers = {},
+        additionalDelay: number = 0,
+    ) {
+        return this.simulateClick(1, element, modifiers, additionalDelay)
     },
 }
 
-const getMouseEvent = (mouseEventType: string, buttons: number, shiftKey: boolean = false) =>
+const getMouseEvent = (
+    mouseEventType: string,
+    buttons: number,
+    modifiers: Modifiers = {},
+) =>
     new MouseEvent(mouseEventType, {
-        shiftKey,
+        shiftKey: modifiers.shiftKey || false,
+        metaKey: modifiers.metaKey || false,
+        ctrlKey: modifiers.ctrlKey || false,
         view: window,
         bubbles: true,
         cancelable: true,

--- a/src/ts/core/common/platform.ts
+++ b/src/ts/core/common/platform.ts
@@ -1,0 +1,4 @@
+/**
+ * Mac uses command, and windows uses ctrl for some commands
+ */
+export const isMacOS = () => window.navigator.platform === 'MacIntel';

--- a/src/ts/core/features/vim-mode/commands/hint-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/hint-commands.ts
@@ -1,6 +1,7 @@
 import {getHint, HINT_IDS, DEFAULT_HINT_KEYS} from 'src/core/features/vim-mode/hint-view'
 import {nmap} from 'src/core/features/vim-mode/vim'
 import {Mouse} from 'src/core/common/mouse'
+import {isMacOS} from 'src/core/common/platform'
 
 export const HintCommands = HINT_IDS.flatMap(n => [
     nmap(DEFAULT_HINT_KEYS[n], `Click Hint ${n}`, () => {
@@ -12,7 +13,14 @@ export const HintCommands = HINT_IDS.flatMap(n => [
     nmap(`shift+${DEFAULT_HINT_KEYS[n]}`, `Shift Click Hint ${n}`, () => {
         const hint = getHint(n)
         if (hint) {
-            Mouse.leftClick(hint, true)
+            Mouse.leftClick(hint, {shiftKey: true})
+        }
+    }),
+    nmap(`ctrl+shift+${DEFAULT_HINT_KEYS[n]}`, `Ctrl Shift Click Hint ${n}`, () => {
+        const hint = getHint(n)
+        if (hint) {
+            // Don't ctrl click on mac, otherwise it'll open up the right click menu
+            Mouse.leftClick(hint, {shiftKey: true, metaKey: isMacOS(), ctrlKey: !isMacOS()})
         }
     }),
 ])

--- a/src/ts/core/roam/references.ts
+++ b/src/ts/core/roam/references.ts
@@ -36,7 +36,7 @@ export const openParentPage = (shiftKey: boolean = false) => {
         return
     }
 
-    Mouse.leftClick(parentLink, shiftKey)
+    Mouse.leftClick(parentLink, { shiftKey })
 }
 
 const getMentionsButton = (blockElement: BlockElement | null): HTMLElement | null => {
@@ -54,6 +54,6 @@ const getMentionsButton = (blockElement: BlockElement | null): HTMLElement | nul
 export const openMentions = (shiftKey: boolean = false) => {
     const mentionsButton = getMentionsButton(RoamBlock.selected().element)
     if (mentionsButton) {
-        Mouse.leftClick(mentionsButton, shiftKey)
+        Mouse.leftClick(mentionsButton, { shiftKey })
     }
 }


### PR DESCRIPTION
I learned that you can open mentions of a link with `ctrl+shift+click`. This exposes that via the vim hints