### PR TITLE
Fix drag and dropping bullets in spatial sidebars

### DIFF
--- a/src/ts/core/features/spatial-mode/index.ts
+++ b/src/ts/core/features/spatial-mode/index.ts
@@ -137,7 +137,7 @@ const startSpatialGraphMode = async (previousGraphData?: GraphData) => {
         })
 
         // Block the native drag and drop. It re-triggers layouts
-        document.querySelectorAll(`${PANEL_SELECTOR} [draggable="true"]`).forEach(dragHandle => {
+        document.querySelectorAll(`${PANEL_SELECTOR} [draggable="true"].window-headers`).forEach(dragHandle => {
             dragHandle.setAttribute('draggable', 'false');
         });
 


### PR DESCRIPTION
Oops, I forgot that disabling drag and drop for the headers would also affect drag and drop for the bullets.