### PR TITLE
Fix sidebar panels fail to connect to each other occasionally (maybe has to do with emojis in titles?)

### DIFF
--- a/src/ts/core/features/spatial-mode/graph-visualization.ts
+++ b/src/ts/core/features/spatial-mode/graph-visualization.ts
@@ -192,7 +192,7 @@ export class GraphVisualization {
                     setStyleIfDifferentEnough(node, 'height', panelElement.offsetHeight + 25)
                 }
             })
-        });
+        })
 
         this.layout?.stop()
         if (SpatialSettings.getLayoutDuration() === 0) {
@@ -234,7 +234,7 @@ export class GraphVisualization {
     }
 
     private getEdge(source: string, target: string): EdgeSingular {
-        return this.cy.$(`edge[source = "${source}"][target = "${target}"]`)[0]
+        return this.cy.filter(ele => ele.isEdge() && ele.target().id() === target && ele.source().id() === source)[0]
     }
 
     save(): GraphData {
@@ -315,7 +315,6 @@ export class GraphVisualization {
         }
     }
 }
-
 
 /**
  * Ignore 1px changes, so the panels don't flicker when you enter/exit blocks


### PR DESCRIPTION
I ran into a bug where a certain sidebar page wasn't forking new pages off of it. Opened links just were just disconnected. It only happened when forking from that particular sidebar page though.

I narrowed it down to Cytoscape mistakenly thinking that the edge had already been drawn. (It refuses to draw a duplicate edge in this case).

When I checked for the duplicate edge in the debugger, I saw that the Cytoscape filter was selecting the incorrect edges:

```javascript
// Try to look for edges from Foo -> Bar
this.cy.$(`edge[source = "Foo"][target = "Bar"]`).target().id() // "Baz"
// It found an edge that didn't even go to Bar
```

It might've had something to emojis being in the title. I switched it to explicitly filtering and comparing ids, which seemed to fix the problem.