### PR TITLE
Fix blocks in main panel not stretching all the way horizontally in Spatial Mode

### DIFF
--- a/src/ts/core/features/spatial-mode/spatial-container.ts
+++ b/src/ts/core/features/spatial-mode/spatial-container.ts
@@ -46,6 +46,10 @@ export const getCytoscapeContainer = () => {
         .sidebar-content > div > div {
             border: none !important;
         }
+        /* these divs prevent blocks on the main panel from taking up the whole horizontal space */
+        ${Selectors.mainBody} .rm-block-separator {
+            display: none;
+        }
         /* hide sidebar toggle icon */
         ${Selectors.sidebar} .bp3-icon-menu-open {
             display: none;


### PR DESCRIPTION
Before:

<img width="742" alt="Screen Shot 2021-03-16 at 1 22 31 PM" src="https://user-images.githubusercontent.com/1150079/111375236-3dafa800-865b-11eb-8dfb-35b200b2e5c9.png">

After:

<img width="735" alt="Screen Shot 2021-03-16 at 1 24 27 PM" src="https://user-images.githubusercontent.com/1150079/111375252-40aa9880-865b-11eb-83f5-64721c19edd0.png">
