### PR TITLE
Add block collapse functionality and UI navigation methods

### DIFF
--- a/src/@types/roam/index.d.ts
+++ b/src/@types/roam/index.d.ts
@@ -1,0 +1,24 @@
+interface RoamAlphaAPI {
+    q(query: string, ...params: any[]): any[][]
+    pull(pattern: string, id: number | [string, string]): Record<string, any>
+    updateBlock(params: {block: {uid: string; string?: string; open?: boolean}}): void
+    createBlock(params: {location: {parentUid: string; order: number}; block: {string: string}}): void
+    deleteBlock(params: {block: {uid: string}}): void
+    moveBlock(params: {location: {parentUid: string; order: number}; block: {uid: string}}): void
+
+    ui: {
+        getFocusedBlock(): {'block-uid': string} | null
+        setBlockFocusAndContext(params: {location: {'block-uid': string; 'window-id': string}}): void
+        mainWindow: {
+            openBlock(params: {block: {uid: string}}): void
+            openPage(params: {page: {uid: string}}): void
+        }
+        rightSidebar: {
+            addWindow(params: {window: {type: string; 'block-uid': string}}): void
+        }
+    }
+}
+
+interface Window {
+    roamAlphaAPI: RoamAlphaAPI
+}

--- a/src/ts/core/features/block-manipulation.ts
+++ b/src/ts/core/features/block-manipulation.ts
@@ -1,9 +1,10 @@
 import {copyBlockEmbed, copyBlockReference} from 'src/core/roam/block'
 
+import {Selectors} from 'src/core/roam/selectors'
+
 import {Feature, Shortcut} from '../settings'
 import {RoamNode, Selection} from '../roam/roam-node'
 import {Roam} from '../roam/roam'
-import {Keyboard} from '../common/keyboard'
 
 export const config: Feature = {
     id: 'block_manipulation',
@@ -49,8 +50,21 @@ export const config: Feature = {
 }
 
 const collapseBlockIntoParent = async () => {
-    await Roam.moveCursorToStart()
-    await Keyboard.pressBackspace()
+    const input = Roam.getRoamBlockInput()
+    if (!input) return
+
+    // Walk up: current block container -> parent block container
+    const currentContainer = input.closest(Selectors.blockContainer)
+    const parentContainer = currentContainer?.parentElement?.closest(Selectors.blockContainer)
+    if (!parentContainer) return
+
+    const parentBlock = parentContainer.querySelector(Selectors.block) as HTMLElement
+    if (!parentBlock) return
+
+    // Collapse the parent (folds its children, hiding the current block)
+    await Roam.toggleFoldBlock(parentBlock)
+    // Focus the parent block
+    await Roam.activateBlock(parentBlock)
 }
 
 const duplicate = () => {

--- a/src/ts/core/features/block-manipulation.ts
+++ b/src/ts/core/features/block-manipulation.ts
@@ -3,6 +3,7 @@ import {copyBlockEmbed, copyBlockReference} from 'src/core/roam/block'
 import {Feature, Shortcut} from '../settings'
 import {RoamNode, Selection} from '../roam/roam-node'
 import {Roam} from '../roam/roam'
+import {Keyboard} from '../common/keyboard'
 
 export const config: Feature = {
     id: 'block_manipulation',
@@ -37,7 +38,19 @@ export const config: Feature = {
             initValue: 'ctrl+meta+c',
             onPress: () => copyBlockEmbed(Roam.getRoamBlockInput()?.id),
         } as Shortcut,
+        {
+            type: 'shortcut',
+            id: 'collapseBlockIntoParent',
+            label: 'Collapse block into parent',
+            initValue: 'Meta+shift+up',
+            onPress: () => collapseBlockIntoParent(),
+        } as Shortcut,
     ],
+}
+
+const collapseBlockIntoParent = async () => {
+    await Roam.moveCursorToStart()
+    await Keyboard.pressBackspace()
 }
 
 const duplicate = () => {

--- a/src/ts/core/features/block-manipulation.ts
+++ b/src/ts/core/features/block-manipulation.ts
@@ -1,10 +1,9 @@
 import {copyBlockEmbed, copyBlockReference} from 'src/core/roam/block'
 
-import {Selectors} from 'src/core/roam/selectors'
-
 import {Feature, Shortcut} from '../settings'
 import {RoamNode, Selection} from '../roam/roam-node'
 import {Roam} from '../roam/roam'
+import {RoamDb} from '../roam/roam-db'
 
 export const config: Feature = {
     id: 'block_manipulation',
@@ -49,22 +48,15 @@ export const config: Feature = {
     ],
 }
 
-const collapseBlockIntoParent = async () => {
-    const input = Roam.getRoamBlockInput()
-    if (!input) return
+const collapseBlockIntoParent = () => {
+    const childUid = RoamDb.getFocusedBlockUid()
+    if (!childUid) return
 
-    // Walk up: current block container -> parent block container
-    const currentContainer = input.closest(Selectors.blockContainer)
-    const parentContainer = currentContainer?.parentElement?.closest(Selectors.blockContainer)
-    if (!parentContainer) return
+    const parentUid = RoamDb.getParentBlockUid(childUid)
+    if (!parentUid) return
 
-    const parentBlock = parentContainer.querySelector(Selectors.block) as HTMLElement
-    if (!parentBlock) return
-
-    // Collapse the parent (folds its children, hiding the current block)
-    await Roam.toggleFoldBlock(parentBlock)
-    // Focus the parent block
-    await Roam.activateBlock(parentBlock)
+    RoamDb.setBlockOpen(parentUid, false)
+    RoamDb.focusBlock(parentUid)
 }
 
 const duplicate = () => {

--- a/src/ts/core/roam/roam-db.ts
+++ b/src/ts/core/roam/roam-db.ts
@@ -39,6 +39,36 @@ export const RoamDb = {
         runInPageContext((...args: any[]) => window.roamAlphaAPI.updateBlock(...args), {block: {uid, string: newText}})
     },
 
+    getFocusedBlockUid(): string | null {
+        return runInPageContext(() => {
+            // @ts-ignore
+            const focused = window.roamAlphaAPI.ui.getFocusedBlock()
+            return focused ? focused['block-uid'] : null
+        })
+    },
+
+    getParentBlockUid(childUid: string): string | null {
+        const results = this.query(
+            '[:find ?parent-uid :in $ ?child-uid :where [?child :block/uid ?child-uid] [?parent :block/children ?child] [?parent :block/uid ?parent-uid]]',
+            childUid
+        )
+        return results?.[0]?.[0] ?? null
+    },
+
+    setBlockOpen(uid: string, open: boolean) {
+        // @ts-ignore
+        runInPageContext((...args: any[]) => window.roamAlphaAPI.updateBlock(...args), {block: {uid, open}})
+    },
+
+    focusBlock(uid: string) {
+        runInPageContext((...args: any[]) => {
+            // @ts-ignore
+            window.roamAlphaAPI.ui.setBlockFocusAndContext({
+                location: {'block-uid': args[0], 'window-id': 'main-window'},
+            })
+        }, uid)
+    },
+
     getAllPages(): RoamPage[] {
         return this.query(
             '[:find ?uid ?title :where [?page :node/title ?title] [?page :block/uid ?uid]]'

--- a/src/ts/core/roam/roam-db.ts
+++ b/src/ts/core/roam/roam-db.ts
@@ -7,16 +7,14 @@ type RoamPage = {
 
 export const RoamDb = {
     getBlockById(dbId: number) {
-        // @ts-ignore
-        return runInPageContext((...args: any[]) => window.roamAlphaAPI.pull(...args), '[*]', dbId)
+        return runInPageContext((pattern: string, id: number) => window.roamAlphaAPI.pull(pattern, id), '[*]', dbId)
     },
 
     query(query: string, ...params: any[]) {
         console.log('Executing Roam DB query', query)
         console.log('Query params', params)
 
-        // @ts-ignore
-        return runInPageContext((...args: any[]) => window.roamAlphaAPI.q(...args), query, ...params)
+        return runInPageContext((q: string, ...p: any[]) => window.roamAlphaAPI.q(q, ...p), query, ...params)
     },
 
     queryFirst(query: string, ...params: any[]) {
@@ -35,13 +33,13 @@ export const RoamDb = {
     },
 
     updateBlockText(uid: string, newText: string) {
-        // @ts-ignore
-        runInPageContext((...args: any[]) => window.roamAlphaAPI.updateBlock(...args), {block: {uid, string: newText}})
+        runInPageContext((params: {block: {uid: string; string: string}}) => window.roamAlphaAPI.updateBlock(params), {
+            block: {uid, string: newText},
+        })
     },
 
     getFocusedBlockUid(): string | null {
         return runInPageContext(() => {
-            // @ts-ignore
             const focused = window.roamAlphaAPI.ui.getFocusedBlock()
             return focused ? focused['block-uid'] : null
         })
@@ -56,15 +54,15 @@ export const RoamDb = {
     },
 
     setBlockOpen(uid: string, open: boolean) {
-        // @ts-ignore
-        runInPageContext((...args: any[]) => window.roamAlphaAPI.updateBlock(...args), {block: {uid, open}})
+        runInPageContext((params: {block: {uid: string; open: boolean}}) => window.roamAlphaAPI.updateBlock(params), {
+            block: {uid, open},
+        })
     },
 
     focusBlock(uid: string) {
-        runInPageContext((...args: any[]) => {
-            // @ts-ignore
+        runInPageContext((blockUid: string) => {
             window.roamAlphaAPI.ui.setBlockFocusAndContext({
-                location: {'block-uid': args[0], 'window-id': 'main-window'},
+                location: {'block-uid': blockUid, 'window-id': 'main-window'},
             })
         }, uid)
     },


### PR DESCRIPTION
## Summary
This PR adds new methods to interact with Roam's block UI and implements a "collapse block into parent" feature that allows users to collapse a focused block and move focus to its parent block.

## Key Changes
- **New RoamDb methods** for block UI interaction:
  - `getFocusedBlockUid()`: Retrieves the UID of the currently focused block
  - `getParentBlockUid()`: Queries the database to find a block's parent UID
  - `setBlockOpen()`: Opens or closes a block's children
  - `focusBlock()`: Sets focus and context to a specific block

- **New block manipulation feature**:
  - Added `collapseBlockIntoParent` shortcut (Meta+shift+up) that collapses the focused block and moves focus to its parent
  - Implements the feature using the new RoamDb methods

## Implementation Details
- The new methods use Roam's Alpha API (`window.roamAlphaAPI`) for UI operations and Datalog queries for database lookups
- The collapse feature safely handles edge cases by checking for null values before proceeding
- TypeScript ignore comments are used where Roam's API types are not fully defined

https://claude.ai/code/session_01Cf5zN6S6G3DRHQb2smzKgA