### PR TITLE
Fix parent focus after collapse and add vim normal mode support

### DIFF
--- a/src/ts/core/features/block-manipulation.ts
+++ b/src/ts/core/features/block-manipulation.ts
@@ -1,9 +1,10 @@
-import {copyBlockEmbed, copyBlockReference} from 'src/core/roam/block'
+import {copyBlockEmbed, copyBlockReference, getBlockUid} from 'src/core/roam/block'
 
 import {Feature, Shortcut} from '../settings'
 import {RoamNode, Selection} from '../roam/roam-node'
 import {Roam} from '../roam/roam'
 import {RoamDb} from '../roam/roam-db'
+import {Selectors} from '../roam/selectors'
 
 export const config: Feature = {
     id: 'block_manipulation',
@@ -48,15 +49,19 @@ export const config: Feature = {
     ],
 }
 
-const collapseBlockIntoParent = () => {
-    const childUid = RoamDb.getFocusedBlockUid()
+export const collapseBlockIntoParent = (blockUid?: string) => {
+    const childUid = blockUid || getBlockUid(Roam.getRoamBlockInput()?.id || '')
     if (!childUid) return
 
     const parentUid = RoamDb.getParentBlockUid(childUid)
     if (!parentUid) return
 
     RoamDb.setBlockOpen(parentUid, false)
-    RoamDb.focusBlock(parentUid)
+
+    const parentBlock = document.querySelector(`${Selectors.block}[id$="${parentUid}"]`) as HTMLElement
+    if (parentBlock) {
+        Roam.activateBlock(parentBlock)
+    }
 }
 
 const duplicate = () => {

--- a/src/ts/core/features/vim-mode/commands/block-manipulation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/block-manipulation-commands.ts
@@ -33,5 +33,5 @@ const collapseIntoParent = () => {
 export const BlockManipulationCommands = [
     nimap('command+shift+h', 'Move Block Up', moveBlockUp),
     nimap('command+shift+k', 'Move Block Down', moveBlockDown),
-    nmap('shift+z', 'Collapse Into Parent', collapseIntoParent),
+    nmap('shift+ctrl+z', 'Collapse Into Parent', collapseIntoParent),
 ]

--- a/src/ts/core/features/vim-mode/commands/block-manipulation-commands.ts
+++ b/src/ts/core/features/vim-mode/commands/block-manipulation-commands.ts
@@ -1,6 +1,10 @@
-import {nimap} from 'src/core/features/vim-mode/vim'
+import {nimap, nmap} from 'src/core/features/vim-mode/vim'
 import {Keyboard} from 'src/core/common/keyboard'
 import {RoamBlock} from 'src/core/features/vim-mode/roam/roam-block'
+import {getBlockUid} from 'src/core/roam/block'
+import {RoamDb} from 'src/core/roam/roam-db'
+import {Selectors} from 'src/core/roam/selectors'
+import {VimRoamPanel} from 'src/core/features/vim-mode/roam/roam-vim-panel'
 
 const moveBlockUp = async () => {
     RoamBlock.selected().edit()
@@ -12,7 +16,22 @@ const moveBlockDown = async () => {
     await Keyboard.simulateKey(Keyboard.DOWN_ARROW, 0, {metaKey: true, shiftKey: true})
 }
 
+const collapseIntoParent = () => {
+    const selected = RoamBlock.selected()
+    const uid = getBlockUid(selected.id)
+    const parentUid = RoamDb.getParentBlockUid(uid)
+    if (!parentUid) return
+
+    RoamDb.setBlockOpen(parentUid, false)
+
+    const parentBlock = document.querySelector(`${Selectors.block}[id$="${parentUid}"]`) as HTMLElement
+    if (parentBlock) {
+        VimRoamPanel.selected().selectBlock(parentBlock.id)
+    }
+}
+
 export const BlockManipulationCommands = [
     nimap('command+shift+h', 'Move Block Up', moveBlockUp),
     nimap('command+shift+k', 'Move Block Down', moveBlockDown),
+    nmap('shift+z', 'Collapse Into Parent', collapseIntoParent),
 ]


### PR DESCRIPTION
- Use DOM-based activation (querySelector + activateBlock) instead of roamAlphaAPI.ui.setBlockFocusAndContext which doesn't work through runInPageContext's synchronous script injection
- Add Shift+Z in vim normal mode to collapse into parent and select it in the vim panel without entering insert mode

https://claude.ai/code/session_01Cf5zN6S6G3DRHQb2smzKgA